### PR TITLE
Variable names are also displayed in variable shadowing

### DIFF
--- a/src/simpleChecker.ml
+++ b/src/simpleChecker.ml
@@ -185,7 +185,7 @@ let init_tyenv fenv { name; args; _ } =
 
 let add_var v t ctxt =
   if StringMap.mem v ctxt.tyenv then
-    failwith "variable shadowing"
+    failwith ("variable shadowing: " ^ v)
   else
     { ctxt with tyenv = StringMap.add v t ctxt.tyenv }
 


### PR DESCRIPTION
When a variable declaration is duplicated, not only the error message "variable shadowing" but also the duplicated variable is displayed.